### PR TITLE
Estrutura inicial para anuncios no Meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # teste-codex
+
+## Estrutura de Anúncio para Meta (Facebook)
+
+Este projeto fornece um ponto de partida simples para criar campanhas de anúncio utilizando a API de Marketing do Facebook.
+
+### Como utilizar
+
+1. Instale as dependências:
+   ```bash
+   pip install facebook-business
+   ```
+2. Defina as seguintes variáveis de ambiente com suas credenciais:
+   - `FB_APP_ID`
+   - `FB_APP_SECRET`
+   - `FB_ACCESS_TOKEN`
+   - `FB_AD_ACCOUNT_ID`
+3. Execute o script de exemplo em `src/facebook_ad_setup.py` para criar uma campanha básica.
+
+### Arquitetura
+
+- `src/` contém códigos de apoio para interação com a API.
+- Futuramente, novos scripts e testes poderão ser adicionados aqui.

--- a/src/facebook_ad_setup.py
+++ b/src/facebook_ad_setup.py
@@ -1,0 +1,29 @@
+import os
+
+from facebook_business.api import FacebookAdsApi
+from facebook_business.adobjects.adaccount import AdAccount
+from facebook_business.adobjects.campaign import Campaign
+
+APP_ID = os.getenv("FB_APP_ID")
+APP_SECRET = os.getenv("FB_APP_SECRET")
+ACCESS_TOKEN = os.getenv("FB_ACCESS_TOKEN")
+AD_ACCOUNT_ID = os.getenv("FB_AD_ACCOUNT_ID")
+
+
+def create_campaign(name: str) -> Campaign:
+    """Cria uma campanha simples pausada."""
+    FacebookAdsApi.init(APP_ID, APP_SECRET, ACCESS_TOKEN)
+    account = AdAccount(AD_ACCOUNT_ID)
+    params = {
+        "name": name,
+        "objective": "LINK_CLICKS",
+        "status": "PAUSED",
+    }
+    campaign = account.create_campaign(params=params)
+    return campaign
+
+
+if __name__ == "__main__":
+    nome = os.environ.get("FB_CAMPAIGN_NAME", "Campanha de Exemplo")
+    campanha = create_campaign(nome)
+    print("Campanha criada:", campanha)


### PR DESCRIPTION
## Summary
- adiciona README detalhando o uso da API de Marketing do Facebook
- inclui script `facebook_ad_setup.py` para criar uma campanha basica

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68489b2eff048323bcc940789863cb10