### PR TITLE
Add automation placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # teste-codex
+
+This repository contains automation tools.
+
+## meta_ads_automation.py
+
+A simple script with placeholder functions to connect to Meta Ads and Shopify APIs.
+
+### Setup
+
+Use Python 3.8 or newer. Install any required packages (e.g. `requests`) with pip:
+
+```bash
+pip install requests
+```
+
+### Example
+
+Run the script by exporting your credentials as environment variables:
+
+```bash
+META_ADS_TOKEN=example_meta_token \
+SHOPIFY_API_KEY=example_key \
+SHOPIFY_PASSWORD=example_password \
+SHOPIFY_SHOP_NAME=your-shop-name \
+python meta_ads_automation.py
+```

--- a/meta_ads_automation.py
+++ b/meta_ads_automation.py
@@ -1,0 +1,26 @@
+# meta_ads_automation.py
+"""Automate basic operations between Meta Ads and Shopify."""
+
+import os
+
+
+def connect_meta_ads(access_token: str):
+    """Placeholder for connecting to Meta Ads API."""
+    # TODO: Implement API call logic
+    print(f"Connecting to Meta Ads with token: {access_token[:4]}...")
+
+
+def connect_shopify(api_key: str, password: str, shop_name: str):
+    """Placeholder for connecting to Shopify API."""
+    # TODO: Implement API call logic
+    print(f"Connecting to Shopify shop: {shop_name}")
+
+
+if __name__ == "__main__":
+    meta_token = os.environ.get("META_ADS_TOKEN", "")
+    shopify_key = os.environ.get("SHOPIFY_API_KEY", "")
+    shopify_password = os.environ.get("SHOPIFY_PASSWORD", "")
+    shopify_shop = os.environ.get("SHOPIFY_SHOP_NAME", "")
+
+    connect_meta_ads(meta_token)
+    connect_shopify(shopify_key, shopify_password, shopify_shop)


### PR DESCRIPTION
## Summary
- create `meta_ads_automation.py` with placeholder functions for Meta Ads and Shopify API connections
- expand `README.md` with setup info and usage example

## Testing
- `META_ADS_TOKEN=mytoken SHOPIFY_API_KEY=mykey SHOPIFY_PASSWORD=pass SHOPIFY_SHOP_NAME=mystore python meta_ads_automation.py`

------
https://chatgpt.com/codex/tasks/task_e_684a36c0b5048323b85d5108d9105558